### PR TITLE
Fix carrierwave.rb: use correct AWS var name

### DIFF
--- a/shopinvader/config/initializers/carrierwave.rb
+++ b/shopinvader/config/initializers/carrierwave.rb
@@ -21,9 +21,7 @@ CarrierWave.configure do |config|
 
     # Use a different endpoint (eg: another provider such as Exoscale)
     if ENV['S3_ENDPOINT'].present?
-      config.aws_credentials.config = AWS.config({
-        s3_endpoint: ENV['S3_ENDPOINT']
-      })
+      config.aws_credentials[:endpoint] = ENV['S3_ENDPOINT']
     end
 
     # Put your CDN host below instead


### PR DESCRIPTION
I've tried deploying w/ a custom endpoint and I got this error:

`/usr/src/app/config/initializers/carrierwave.rb:24:in `block in <top (required)>': uninitialized constant AWS (NameError)`

as per  https://stackoverflow.com/questions/22826432/error-uninitialized-constant-aws-nameerror
seems the AWS var name changed and we are using sdk3 already.