### PR TITLE
Fix handling of PUMA_MAX_RAM env var

### DIFF
--- a/shopinvader/config/puma.rb
+++ b/shopinvader/config/puma.rb
@@ -18,7 +18,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 before_fork do
   require 'puma_worker_killer'
   PumaWorkerKiller.config do |config|
-    config.ram        = ENV['PUMA_MAX_RAM'] || 4096
+    config.ram        = Integer(ENV['PUMA_MAX_RAM'] || 4096)
     config.frequency  = 60
     config.rolling_restart_frequency = 12 * 3600
   end


### PR DESCRIPTION
When the `PUMA_MAX_RAM` environment variable is set, `PumaWorkerKiller` was apaprently mostly disabled: the typicall recurring message `PumaWorkerKiller: Consuming 338.73828125 mb with master and 2 workers..` was not present in the log.

Converting that variable to an Integer before passing it to the PumaWorkerKiller configuration seems to fix this. 

cc/ @Cedric-Pigeon 