### PR TITLE
fix: for minio shopinvader

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ S3_BUCKET_REGION
 S3_ASSET_HOST_URL
 S3_CACHE_CONTROL
 S3_ENDPOINT (optionnal: usefull when using S3 compatible provider)
+S3_PATH_STYLE (optionnal: required by some S3 compatible provider like Minio)
 ```
 
 ## SMTP configuration

--- a/shopinvader/config/initializers/carrierwave.rb
+++ b/shopinvader/config/initializers/carrierwave.rb
@@ -24,6 +24,12 @@ CarrierWave.configure do |config|
       config.aws_credentials[:endpoint] = ENV['S3_ENDPOINT']
     end
 
+    # For some endpoint like minio you need to rewrite path 
+    if ENV['S3_PATH_STYLE'].present?
+      config.aws_credentials[:force_path_style] = ENV['S3_PATH_STYLE']
+    end
+    
+
     # Put your CDN host below instead
     if ENV['S3_ASSET_HOST_URL'].present?
       config.asset_host = ENV['S3_ASSET_HOST_URL']


### PR DESCRIPTION
* Purpose
If you use Minio in background to store asset, it require path_style set to true, if not, you are unable to connect.

