### PR TITLE
fix: use fixed version of locomotivecsm for fix_path_style

### DIFF
--- a/shopinvader/Gemfile
+++ b/shopinvader/Gemfile
@@ -7,7 +7,7 @@ gem 'devise'
 gem 'locomotivecms_common', github: 'locomotivecms/common'
 gem 'custom_fields', github: 'locomotivecms/custom_fields'
 gem 'locomotivecms_steam', github: 'akretion/steam', branch: 'all-fixes'
-gem 'locomotivecms', github: 'locomotivecms/engine'
+gem 'locomotivecms', github: 'vrenaville/engine', branch: 'fix_path_style'
 
 gem 'shop_invader', github: 'shopinvader/locomotive-shopinvader', branch: 'v4.0.x'
 gem 'mongo_session_store', '~> 3.1.0'

--- a/shopinvader/Gemfile.lock
+++ b/shopinvader/Gemfile.lock
@@ -55,10 +55,11 @@ GIT
       mongoid (>= 6.2, < 7.0)
 
 GIT
-  remote: https://github.com/locomotivecms/engine.git
-  revision: bb2a3a3fa24adf4e953d2f96f8419eb032fadb16
+  remote: https://github.com/vrenaville/engine.git
+  revision: 8b93b4e1a63c715c89a030211064edbd2cbdd34d
+  branch: fix_path_style
   specs:
-    locomotivecms (4.0.3)
+    locomotivecms (4.1.0.rc1)
       actionmailer-with-request (~> 0.5.0)
       adomain (~> 0.1.1)
       autoprefixer-rails (~> 8.0.0)


### PR DESCRIPTION
* Purpose
Locomotive need to be patch to be able to use, fix_path_style, it's required for some s3 backend like Minio