### PR TITLE
chore: bump the version of Locomotive engine to the last commit

### DIFF
--- a/shopinvader/Gemfile
+++ b/shopinvader/Gemfile
@@ -19,7 +19,7 @@ gem 'mimemagic', '~> 0.4.3'
 
 # gem 'locomotivecms_search', path: '../../search'
 
-gem 'locomotivecms', github: 'locomotivecms/engine', ref: 'e6fb512c'
+gem 'locomotivecms', github: 'locomotivecms/engine', ref: '417d4a8'
 gem 'locomotivecms_steam', github: 'locomotivecms/steam', ref: 'ba10b57b', require: false
 gem 'locomotivecms_common', github: 'locomotivecms/common', ref: 'c78da158', require: false
 # gem 'locomotivecms_search', github: 'locomotivecms/search', ref: '35e5813'

--- a/shopinvader/Gemfile.lock
+++ b/shopinvader/Gemfile.lock
@@ -23,8 +23,8 @@ GIT
 
 GIT
   remote: https://github.com/locomotivecms/engine.git
-  revision: e6fb512c08f7108eb024b7e56b8f4f153570f78e
-  ref: e6fb512c
+  revision: 417d4a8fc5fc8252f95603e71f127a976bcd81df
+  ref: 417d4a8
   specs:
     locomotivecms (4.2.0.alpha2)
       actionmailer-with-request (~> 0.5.0)


### PR DESCRIPTION
Last commit: August, 1st.

It solves the following issue: https://github.com/locomotivecms/engine/pull/1424